### PR TITLE
Fix error in RCSplineConvert

### DIFF
--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -30,13 +30,13 @@ MainCodeRun <- function() {
     ## Mark entries as Metropolitan or Non-Metropolitan
     selected.data.metro.mark <- Metrocheck(selected.data)
     ## Create Metropolitan Sample and Non-Metropolitan Sample
-    Metropolitan.Sample <- selected.data.metro.mark[ which(selected.data.metro.mark$metropolitan == "Yes"), ]
-    Non.Metropolitan.Sample <- selected.data.metro.mark[ which(selected.data.metro.mark$metropolitan == "No"), ]
+    Metropolitan.Sample <- selected.data.metro.mark[selected.data.metro.mark$metropolitan == "Yes", ]
+    Non.Metropolitan.Sample <- selected.data.metro.mark[selected.data.metro.mark$metropolitan == "No", ]
     rm(selected.data.metro.mark)
     ## Mark entries as valid (>170 events) individual centres
     selected.data.ind.mark <- IndividualCentreCheck(selected.data)
     ## Create Multi Centre Sample (= A combination of all valid individual centres)
-    Multi.Centre.Sample <- selected.data.ind.mark[ which(selected.data.ind.mark$Valid_Individual_Centre == "Yes"), ]
+    Multi.Centre.Sample <- selected.data.ind.mark[selected.data.ind.mark$Valid_Individual_Centre == "Yes", ]
     ## Create Individual Centre Sample 1-n, where n is the total number of valid individual centres 
     #? I´m trying to create a function that outputs a data.frame named Individual.Centre.Sample.1, Individual.Centre.Sample.2... and so on.
     #? My inital thought was extracting each unique "Sjukhuskod" present in Multi.Centre.Sample as its own data.frame, and having R name 

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -35,13 +35,20 @@ MainCodeRun <- function() {
     rm(selected.data.metro.mark)
     ## Mark entries as valid (>170 events) individual centres
     selected.data.ind.mark <- IndividualCentreCheck(selected.data)
-    ## Create Multi Centre Sample (= A combination of all valid individual centres)
-    Multi.Centre.Sample <- selected.data.ind.mark[selected.data.ind.mark$Valid_Individual_Centre == "Yes", ]
+    ## Create Multi Centre Sample (All data)
+    Multi.Centre.Sample <- selected.data.ind.mark
+
     ## Create Individual Centre Sample 1-n, where n is the total number of valid individual centres 
     #? I´m trying to create a function that outputs a data.frame named Individual.Centre.Sample.1, Individual.Centre.Sample.2... and so on.
     #? My inital thought was extracting each unique "Sjukhuskod" present in Multi.Centre.Sample as its own data.frame, and having R name 
     #? the data.frames accordingly. However, I can´get it to work.
-   
+
+    ## Create Single Centre Samples (valid individual centres)
+    centre.ids <- unique(selected.data.ind.mark$Sjukhuskod) # Identify unique IDs
+    centre.ids <- setNames(centre.ids, nm = paste0("centre_", centre.ids)) # Name IDs
+    Single.Centre.Samples <- lapply(centre.ids, SelectSingleCentre, df = selected.data.ind.mark)
+    Single.Centre.Samples <- Single.Centre.Samples[-which(sapply(Single.Centre.Samples, is.null))]
+
     ## DEVELOPMENT AND VALIDATION
     ## Create High Volume Sample Development and Validation
    

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -17,7 +17,9 @@ MainCodeRun <- function() {
     selected.data <- InclusionSelection(selected.data)
     ## Data Cleaning
     selected.data <- DataCleaning(selected.data)
-    ## Convert SBP and RR to restricted cubic splines
+    ## Convert SBP and RR to restricted cubic splines. This is something you
+    ## want to do later, once you have created all your samples and split them
+    ## into development and validation
     selected.data <- RCSplineConvert(selected.data)
   
     ## DATA SETS AND SAMPLES

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -49,7 +49,16 @@ MainCodeRun <- function() {
     Single.Centre.Samples <- lapply(centre.ids, SelectSingleCentre, df = selected.data.ind.mark)
     Single.Centre.Samples <- Single.Centre.Samples[-which(sapply(Single.Centre.Samples, is.null))]
     rm(selected.data.ind.mark) 
-    ## Combine samples 
+
+    ## Add samples to list
+    data.sets <- list(high.volume.vs.low.volume = list(high.volume = High.Volume.Sample,
+                                                       low.volume = Low.Volume.Sample),
+                      metropolitan.vs.non.metropolitan = list(metropolitan = Metropolitan.Sample,
+                                                              non.metropolitat = Non.Metropolitan.Sample),
+                      multi.centre.vs.single.centres = list(multi.centre = Multi.Centre.Sample,
+                                                           single.centres = Single.Centre.Samples))
+
+    ## Now you want to do the same operations on each sample in the list 
     
     ## DEVELOPMENT AND VALIDATION
     ## Create High Volume Sample Development and Validation

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -24,8 +24,8 @@ MainCodeRun <- function() {
     ## Mark entries as High Volume or Low Volume
     selected.data.vol.mark <- HighVolumeCheck(selected.data)
     ## Create High Volume Sample and Low Volume Sample
-    High.Volume.Sample <- selected.data.vol.mark[ which(selected.data.vol.mark$High_Volume_Centre == "Yes"), ]
-    Low.Volume.Sample <- selected.data.vol.mark[ which(selected.data.vol.mark$High_Volume_Centre == "No"), ]
+    High.Volume.Sample <- selected.data.vol.mark[selected.data.vol.mark$High_Volume_Centre == "Yes", ]
+    Low.Volume.Sample <- selected.data.vol.mark[selected.data.vol.mark$High_Volume_Centre == "No", ]
     rm(selected.data.vol.mark)
     ## Mark entries as Metropolitan or Non-Metropolitan
     selected.data.metro.mark <- Metrocheck(selected.data)

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -49,6 +49,8 @@ MainCodeRun <- function() {
     Single.Centre.Samples <- lapply(centre.ids, SelectSingleCentre, df = selected.data.ind.mark)
     Single.Centre.Samples <- Single.Centre.Samples[-which(sapply(Single.Centre.Samples, is.null))]
 
+    ## Combine samples 
+    
     ## DEVELOPMENT AND VALIDATION
     ## Create High Volume Sample Development and Validation
    

--- a/MainCodeRun.R
+++ b/MainCodeRun.R
@@ -4,6 +4,8 @@
 MainCodeRun <- function() {
   
     ## Load required packages and source functions
+    ## FuncPack() first needs to be sourced to run
+    source("./functions/FuncPack.R")
     FuncPack()
     ## Set random seed
     set.seed(-41892)

--- a/functions/ImportStudyData.R
+++ b/functions/ImportStudyData.R
@@ -5,8 +5,8 @@
 #' @param data.file.name Character vector of length 1. The name of the study
 #'     data file. Defaults to NULL.
 #' @param data.path Character vector of length 1. The path to the data
-#'     directory. Defaults to "./data/"
-ImportStudyData <- function(data.file.name = NULL, data.path = "./data/") {
+#'     directory. Defaults to "../data/"
+ImportStudyData <- function(data.file.name = NULL, data.path = "../data/") {
 
     ## Error handling
     if (is.null(data.file.name)) 

--- a/functions/InclusionSelection.R
+++ b/functions/InclusionSelection.R
@@ -1,6 +1,6 @@
 #' InclusionSelection
 #'
-#' Selectes only cases with age > 15, or cases where age is registerd as NA.
+#' Selects only cases with age > 15, or cases where age is registerd as NA.
 #' @param df Dataframe. The study sample. Must contain pt_age_yrs No default.
 InclusionSelection <- function(df) {
   

--- a/functions/RCSplineConvert.R
+++ b/functions/RCSplineConvert.R
@@ -24,7 +24,7 @@ RCSplineConvert <- function(df) {
     assign("sbp.knot.locations", sbp.knot.locations, .GlobalEnv)
     ## Insert SBP spline function as new columns into inputted data frme
     sbp.splines <- as.data.frame(sbp.splines)
-    colnames(sbp.splines) <- paste0("ed_sbp_value_spline_", 1:(nk - 2))
+    colnames(sbp.splines) <- paste0("ed_sbp_value_spline_", 1:ncol(sbp.splines))
     df <- cbind(df, sbp.splines)
   
     ## Converting RR to Restricted Cubic Splines
@@ -34,7 +34,7 @@ RCSplineConvert <- function(df) {
     assign("rr.knot.locations", rr.knot.locations, .GlobalEnv)
     ## Insert RR spline function as new columns into inputted data frme
     rr.splines <- as.data.frame(rr.splines)
-    colnames(rr.splines) <- paste0("ed_rr_value_spline_", 1:(nk - 2))
+    colnames(rr.splines) <- paste0("ed_rr_value_spline_", 1:ncol(rr.splines))
     df <- cbind(df, rr.splines)
   
     return(df)

--- a/functions/SelectSingleCentre.R
+++ b/functions/SelectSingleCentre.R
@@ -1,0 +1,22 @@
+#' SelectSingleCentre
+#'
+#'  
+#' @param centre.id A character vector of length 1. The centre id. No default.
+#' @param df A dataframe. Must contain a column "Sjukhuskod". No default.
+#' 
+SelectSingleCentre <- function(centre.id, df) {
+    ## Error handling
+    if (!is.data.frame(df))
+        stop ("Input has to be a data.frame")
+    if (!("Sjukhuskod" %in% colnames(df)))
+        stop ("df has to include the column Sjukhuskod")
+    if (!("Valid_Individual_Centre" %in% colnames(df)))
+        stop ("df has to include the column Valid_Individual_Centre")    
+
+    ## Select single centre
+    centre.sample <- df[df$Sjukhuskod == centre.id, ]
+    return.object <- NULL
+    if (all(centre.sample$Valid_Individual_Centre == "Yes"))
+        return.object <- centre.sample
+    return(return.object)
+}


### PR DESCRIPTION
rcsspline.eval uses only unique knot locations (obviously), and there are only 
three in RR in the simulated data. In that case only one spline basis function 
is created and the error is thrown when we try to assign more column names than 
there are columns in the data. The fix is to use the number of columns to assign 
column names instead of the number of knots asked for.